### PR TITLE
introduce tool choice enum

### DIFF
--- a/src/deepseek.rs
+++ b/src/deepseek.rs
@@ -193,16 +193,10 @@ impl TryFrom<f32> for TopP {
 
 #[derive(Debug)]
 pub enum ToolChoice {
-    NONE,
-    AUTO,
-    REQUIRED,
-    FUNCTION(String),
-}
-
-impl ToolChoice {
-    pub fn new(name: impl Into<String>) -> Self {
-        ToolChoice::FUNCTION(name.into())
-    }
+    None,
+    Auto,
+    Required,
+    Function(String),
 }
 
 // Serialization implementation
@@ -212,10 +206,10 @@ impl serde::Serialize for ToolChoice {
         S: serde::Serializer,
     {
         match self {
-            ToolChoice::NONE => serializer.serialize_str("none"),
-            ToolChoice::AUTO => serializer.serialize_str("auto"),
-            ToolChoice::REQUIRED => serializer.serialize_str("required"),
-            ToolChoice::FUNCTION(name) => {
+            ToolChoice::None => serializer.serialize_str("none"),
+            ToolChoice::Auto => serializer.serialize_str("auto"),
+            ToolChoice::Required => serializer.serialize_str("required"),
+            ToolChoice::Function(name) => {
                 #[derive(serde::Serialize)]
                 struct ToolCall<'a> {
                     #[serde(rename = "type")]

--- a/src/draft.rs
+++ b/src/draft.rs
@@ -69,9 +69,8 @@ fn test() {
         ..Default::default()
     };
 
-    let choice = ToolChoice::AUTO;
-    let test = ToolChoice::FUNCTION("test".to_string());
-    let choice1 = ToolChoice::new("tool_name");
+    let choice = ToolChoice::Auto;
+    let test = ToolChoice::Function("test".to_string());
 }
 
 // API

--- a/src/draft.rs
+++ b/src/draft.rs
@@ -24,7 +24,7 @@
 //     let temp = deepseek::Temperature::CODING;
 // }
 
-use crate::deepseek::{self, ToolChoiceMode};
+use crate::deepseek::{self, ToolChoice};
 
 #[derive(Debug, Clone, Copy)]
 struct Temperature(f32);
@@ -69,8 +69,9 @@ fn test() {
         ..Default::default()
     };
 
-    let choice = deepseek::ToolChoice::new(ToolChoiceMode::Auto);
-    let choice1 = deepseek::ToolChoice::new("tool_name".to_string());
+    let choice = ToolChoice::AUTO;
+    let test = ToolChoice::FUNCTION("test".to_string());
+    let choice1 = ToolChoice::new("tool_name");
 }
 
 // API

--- a/src/draft.rs
+++ b/src/draft.rs
@@ -24,7 +24,7 @@
 //     let temp = deepseek::Temperature::CODING;
 // }
 
-use crate::deepseek;
+use crate::deepseek::{self, ToolChoiceMode};
 
 #[derive(Debug, Clone, Copy)]
 struct Temperature(f32);
@@ -68,6 +68,9 @@ fn test() {
         base_url: "https://openrouter.ai/api/v1",
         ..Default::default()
     };
+
+    let choice = deepseek::ToolChoice::new(ToolChoiceMode::Auto);
+    let choice1 = deepseek::ToolChoice::new("tool_name".to_string());
 }
 
 // API


### PR DESCRIPTION
this is a bit iffy, since it can either be a mode or a function with a name.

Enables you to create a new tool_choice with either a mode:
- none: no tool call -> message generated
- auto: model picks between one/many tool calls or a message
- required: model calls one/many tools

If a function name is specified, this function is invoked. It's a bit odd, since they distinguish between `tool` as part of the `tools` parameter and the `function` to call in the case of `tool_choice`.

Also I am unsure if this API is what we want. Intuitively I like the idiomatic use of `new` here.

This means we create model params in a similar way, e.g.
```rust
let temp = Temperature::CODING;
```

On the other hand I `new` feels a bit odd, since the arguments purpose isn't obvious.

```rust
let choice = deepseek::ToolChoice:AUTO;
let choice1 = deepseek::ToolChoice::new("tool_name".to_string());
```

This only works by breaking naming convention for `ToolChoice`.

The other option I had in mind was to handle it in the same way `Temperature` is handled and add the enum fields as consts:

```rust
impl ToolChoice {
  const AUTO = "auto";
  ...

}
```

In this case the `new` method would be a bit iffy due to the function name being optional.

Just keeping the enum and implementing a `serde::Serialize` is probably the most straightforward approach. This results in yucky API:

```rust
let temp = Temperature::CODING;

let choice_one = ToolChoice::Auto;
let choice_two = ToolChoice::Function("bar_baz");
```

help..